### PR TITLE
Fix for small sample, bring arguments to MFF

### DIFF
--- a/mff/MFF.py
+++ b/mff/MFF.py
@@ -70,13 +70,10 @@ class MFF:
         Oracle Shrinking Approximating Estimator ('oas'). Other options are
         oas, identity and monotone_diagonal.
     
-    lamstar_empirically : boolean, optional(default: True)
-        Indicate whether the smoothness paramater lambda is to be calculated
-        empirically 
-
-    default_lam : float, optional(default: 6.25)
-        Default value of lambda to be used; used when lamstar is not being estimated
-        empirically.
+    default_lam : float, optional(default: -1)
+        The value of lambda to be used for calculating smoothing parameter if 
+        frequency of observations cannot be determined from index names. If this 
+        is set to -1, lambda is calculated empirically. Default is -1.
 
     max_lam : float, optional(default: 129600)
         Maximum value of lamstar to be used for smoothing forecasts when being
@@ -127,7 +124,6 @@ class MFF:
         parallelize = self.parallelize
         n_forecast_error = self.n_forecast_error 
         shrinkage_method = self.shrinkage_method
-        lamstar_empirically = self.lamstar_empirically
         default_lam = self.default_lam
         max_lam = self.max_lam
         
@@ -169,7 +165,6 @@ class MFF:
         W,shrinkage = GenWeightMatrix(pred_list, true_list,
                                       shrinkage_method = shrinkage_method)
         smoothness = GenLamstar(pred_list,true_list,
-                                lamstar_empirically = lamstar_empirically,
                                 default_lam = default_lam,
                                 max_lam = max_lam)
         Phi = GenSmoothingMatrix(W,smoothness)

--- a/mff/MFF.py
+++ b/mff/MFF.py
@@ -8,6 +8,7 @@ import numpy as np
 from sktime.forecasting.base import BaseForecaster
 
 from mff.utils import (
+    CheckTrainingSampleSize,
     DefaultForecaster,
     OrganizeCells,
     StringToMatrixConstraints,
@@ -20,7 +21,6 @@ from mff.utils import (
     GenLamstar,
     GenSmoothingMatrix,
     Reconciliation,
-    check_training_sample_size,
     )
 
 #%% MFF
@@ -129,7 +129,7 @@ class MFF:
         # modify inputs into machine-friendly shape
         df0, all_cells, unknown_cells, known_cells, islands = OrganizeCells(df)
 
-        small_sample: bool = check_training_sample_size(df0,n_forecast_error)
+        small_sample: bool = CheckTrainingSampleSize(df0,n_forecast_error)
 
         # Initiate DefaultForecaster only if a forecaster has not already been 
         # defined by the user. Use OLS PCA if small_sample is True, and Grid Search

--- a/mff/MFF.py
+++ b/mff/MFF.py
@@ -95,8 +95,7 @@ class MFF:
                  parallelize:bool = True,
                  n_forecast_error:int = 5,
                  shrinkage_method:str = 'oas',
-                 lamstar_empirically:bool = True,
-                 default_lam:float = 6.25,
+                 default_lam:float = -1,
                  max_lam:float = 129600):
         
         self.df = df
@@ -106,7 +105,6 @@ class MFF:
         self.parallelize = parallelize
         self.n_forecast_error = n_forecast_error
         self.shrinkage_method = shrinkage_method
-        self.lamstar_empirically = lamstar_empirically
         self.default_lam = default_lam
         self.max_lam = max_lam
 

--- a/mff/examples.py
+++ b/mff/examples.py
@@ -27,7 +27,7 @@ def example1(): # no constraints
     df.iloc[-fh:,0] = np.nan
     
     # apply MFF
-    m = MFF(df,constraints_with_wildcard=[])
+    m = MFF(df,equality_constraints=[])
     df2 = m.fit()
     df0 = m.df0
     df1 = m.df1
@@ -69,11 +69,11 @@ def example2():
     df.iloc[-1,0] = df_true.iloc[-1,0] # island
     #df.iloc[-fh,-1] = df.iloc[:,-1].mean()
     # df.iloc[-3,1] = df_true.iloc[-3,1] # island
-    constraints_with_wildcard = ['A0?+B0?-C0?']
+    equality_constraints = ['A0?+B0?-C0?']
     #ineq_constraints_with_wildcard = ['A0?-0.5'] # A0 <=0.5 for all years
     
     # fit data
-    m = MFF(df,constraints_with_wildcard = constraints_with_wildcard)
+    m = MFF(df,equality_constraints = equality_constraints)
     df2 = m.fit()
     df0 = m.df0
     df1 = m.df1

--- a/mff/tests/tests_MFF.py
+++ b/mff/tests/tests_MFF.py
@@ -86,17 +86,17 @@ def test_MFF_mixed_frequency():
     assert ~np.isnan(df2_list[0].iloc[-1,0])
 
 def test_small_sample_MFF():
-    n = 30
+    n = 20
     p = 2
     fh = 5
     df_true = pd.DataFrame(np.random.rand(n,p),
                       columns=[f'{L}{i}' for i in range(int(np.ceil(p/26))) for L in ascii_uppercase][:p],
                       index=pd.date_range(start='2000',periods=n,freq='YE').year
                       )
-    df_true.iloc[:,-1] = df_true.iloc[:,:-1].sum(axis=1)
+    # df_true.iloc[:,-1] = df_true.iloc[:,:-1].sum(axis=1)
     df = df_true.copy()
     df.iloc[-fh:,:np.ceil(p/2).astype(int)] = np.nan
-    df.iloc[-1,0] = df_true.iloc[-1,0] # island
+    # df.iloc[-1,0] = df_true.iloc[-1,0] # island
     equality_constraints = []
     
     m = MFF(df,equality_constraints = equality_constraints,

--- a/mff/tests/tests_MFF.py
+++ b/mff/tests/tests_MFF.py
@@ -26,9 +26,9 @@ def test_MFF_non_parallel():
     df = df_true.copy()
     df.iloc[-fh:,:np.ceil(p/2).astype(int)] = np.nan
     df.iloc[-1,0] = df_true.iloc[-1,0] # island
-    constraints_with_wildcard = ['A0?+B0?-C0?']
+    equality_constraints = ['A0?+B0?-C0?']
     
-    m = MFF(df,constraints_with_wildcard = constraints_with_wildcard,
+    m = MFF(df,equality_constraints = equality_constraints,
             parallelize=False)
     df2 = m.fit()
 
@@ -47,9 +47,9 @@ def test_MFF_parallel():
     df.iloc[-fh:,:np.ceil(p/2).astype(int)] = np.nan
     df.iloc[-1,0] = df_true.iloc[-1,0] # island
 
-    constraints_with_wildcard = ['A0?+B0?-C0?']
+    equality_constraints = ['A0?+B0?-C0?']
 
-    m = MFF(df,constraints_with_wildcard = constraints_with_wildcard,
+    m = MFF(df,equality_constraints = equality_constraints,
             parallelize=True)
     df2 = m.fit()
 

--- a/mff/tests/tests_MFF.py
+++ b/mff/tests/tests_MFF.py
@@ -84,3 +84,23 @@ def test_MFF_mixed_frequency():
                              constraints_with_wildcard=constraints_with_wildcard)
     df2_list = mff.fit()
     assert ~np.isnan(df2_list[0].iloc[-1,0])
+
+def test_small_sample_MFF():
+    n = 30
+    p = 2
+    fh = 5
+    df_true = pd.DataFrame(np.random.rand(n,p),
+                      columns=[f'{L}{i}' for i in range(int(np.ceil(p/26))) for L in ascii_uppercase][:p],
+                      index=pd.date_range(start='2000',periods=n,freq='YE').year
+                      )
+    df_true.iloc[:,-1] = df_true.iloc[:,:-1].sum(axis=1)
+    df = df_true.copy()
+    df.iloc[-fh:,:np.ceil(p/2).astype(int)] = np.nan
+    df.iloc[-1,0] = df_true.iloc[-1,0] # island
+    equality_constraints = []
+    
+    m = MFF(df,equality_constraints = equality_constraints,
+            parallelize=False)
+    df2 = m.fit()
+
+    assert ~np.isnan(df2.iloc[-1,0]) 

--- a/mff/utils.py
+++ b/mff/utils.py
@@ -983,8 +983,7 @@ def GenWeightMatrix(pred_list,true_list,shrinkage_method='oas'):
 
 def GenLamstar(pred_list: list,
                true_list: list,
-               lamstar_empirically: bool = True,
-               default_lam: float =6.25,
+               default_lam: float = -1,
                max_lam: float =129600):
 
     """
@@ -1000,11 +999,10 @@ def GenLamstar(pred_list: list,
         List of dataframes, with each dataframe containing the actual values
         for a variable corresponding to in-sample predictions stored in
         pred_list.
-    lamstar_empirically : boolean, optional
-        Indicate whether lambda should be calculated emperically, or use
-        commonly used values from the literature. The default is True.
-    default_lam : float, optional
-        The value of lambda to use if none is provided. The default is 6.25.
+    default_lam : float, optional(default: -1)
+        The value of lambda to be used for calculating smoothing parameter if 
+        frequency of observations cannot be determined from index names. If this 
+        is set to -1, lambda is calculated empirically. The default value is -1.
     max_lam : float, optional
         The upperbound of HP filter penalty term (lambda) searched by scipy 
         minimizer. The default is 129600.
@@ -1044,7 +1042,7 @@ def GenLamstar(pred_list: list,
                             index = tsidx_list)
     
     # optimal lambda
-    if lamstar_empirically:
+    if default_lam == -1:
         loss_fn = lambda x,T,yt,yp: \
             (yt - inv(np.eye(T) + x * HP_matrix(T)) @ yp).T @ \
             (yt - inv(np.eye(T) + x * HP_matrix(T)) @ yp)

--- a/mff/utils.py
+++ b/mff/utils.py
@@ -158,9 +158,9 @@ def ForecasterSetup(forecaster:BaseForecaster, df0:pd.DataFrame,
         
         if  minimum_training_obs <=0:
 
-            print('Number of observations too low for given forecast horizon \
-                   and n_sample_splits; consider reducing forecast horizon and\or \
-                   n_sample_splits')
+            print('Number of observations too low for given forecast horizon' 
+                   'and n_sample_splits; consider reducing forecast horizon and/or' 
+                   'n_sample_splits')
             
             forecaster.no_estimation = True
 


### PR DESCRIPTION
- When observations available for training are less than or equal to 15, Elastic Net doesn't work. Therefore, the original DefaultForecaster function is modified to have a parameter small_sample, which when set to True, dropes ElasticNetcv from the list of models to be used in the gridsearch algorithm. In case the number of observations for training are less than or equal to 10, all models give errors, and therefore MFF is modified to give None in this case.

- Brought up arguments from functions to MFF.